### PR TITLE
finding openssl with wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,17 @@ SOURCES      := src/*.cpp
 HEADERS      := src/*.h
 
 # compiler flags
-CFLAGS       := -std=c++20 -Wall -O2 -pthread -lcrypto -lssl -I ./include/
+CXXFLAGS       := -std=c++20 -Wall -O2 -pthread -lcrypto -lssl -I ./include/
+
+OPENSSL_INCLUDE_PATH := $(wildcard /usr/local/Cellar/openssl@3*/*/include)
+ifneq ("$(OPENSSL_INCLUDE_PATH)","")
+CXXFLAGS += -I$(OPENSSL_INCLUDE_PATH)
+endif
+
+OPENSSL_LIB_PATH := $(wildcard /usr/local/Cellar/openssl@3*/*/lib)
+ifneq ("$(OPENSSL_LIB_PATH)","")
+LDFLAGS += -L$(OPENSSL_LIB_PATH)
+endif
 
 # executable
 EXE          := hussar
@@ -13,7 +23,7 @@ EXE_ARGS     := -d docroot -v
 
 # make cli options
 release:
-	$(CXX) $(CFLAGS) $(SOURCES) -o $(EXE)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(SOURCES) -o $(EXE)
 
 run:
 	./$(EXE) $(EXE_ARGS)
@@ -22,7 +32,7 @@ clean:
 	rm -f $(EXE) hello_world
 
 example:
-	$(CXX) $(CFLAGS) -I ./src/ ./examples/hello_world.cpp -o hello_world
+	$(CXX) $(CXXFLAGS) -I ./src/ ./examples/hello_world.cpp -o hello_world
 
 certs:
 	openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days 9 -out cert.pem


### PR DESCRIPTION
* took the liberty of using CXXFLAGS (more standard for the c++ compiler on make)
* finding OpenSSL with wildcard on the Mac (I don't want to introduce CMake on your project)

With these changes, on my Mac with OpenSSL installed through homebrew, the server builds and runs.